### PR TITLE
Update hyper example

### DIFF
--- a/src/getting_started/http_server_example.md
+++ b/src/getting_started/http_server_example.md
@@ -61,10 +61,6 @@ use {
         rt::run,
     },
     futures::{
-        // `TokioDefaultSpawner` tells futures 0.3 futures how to spawn tasks
-        // onto the Tokio runtime.
-        compat::TokioDefaultSpawner,
-
         // Extension traits providing additional methods on futures.
         // `FutureExt` adds methods that work for all futures, whereas
         // `TryFutureExt` adds methods to futures that return `Result` types.
@@ -101,7 +97,7 @@ async fn run_server(addr: SocketAddr) {
         // wrapper to go from a futures 0.3 future (the kind returned by
         // `async fn`) to a futures 0.1 future (the kind used by Hyper).
         .serve(|| service_fn(|req|
-            serve_req(req).boxed().compat(TokioDefaultSpawner)
+            serve_req(req).boxed().compat()
         ));
 
     // Wait for the server to complete serving or exit with an error.
@@ -122,7 +118,7 @@ fn main() {
     // futures 0.1 future.
     let futures_03_future = run_server(addr);
     let futures_01_future =
-        futures_03_future.unit_error().boxed().compat(TokioDefaultSpawner);
+        futures_03_future.unit_error().boxed().compat();
 
     // Finally, we can run the future to completion using the `run` function
     // provided by Hyper.

--- a/src/getting_started/http_server_example.md
+++ b/src/getting_started/http_server_example.md
@@ -16,11 +16,11 @@ Let's add some dependencies to the `Cargo.toml` file:
 # The latest version of the "futures" library, which has lots of utilities
 # for writing async code. Enable the "tokio-compat" feature to include the
 # functions for using futures 0.3 and async/await with the Tokio library.
-futures-preview = { version = "0.3.0-alpha.9", features = ["tokio-compat"] }
+futures-preview = { version = "0.3.0-alpha.13", features = ["compat"] }
 
 # Hyper is an asynchronous HTTP library. We'll use it to power our HTTP
 # server and to make HTTP requests.
-hyper = "0.12.9"
+hyper = "0.12.25"
 
 # Tokio is a runtime for asynchronous I/O applications. Hyper uses
 # it for the default server runtime. The `tokio` crate also provides an
@@ -28,7 +28,7 @@ hyper = "0.12.9"
 # both futures 0.1 futures (the kind used by Hyper and Tokio) and
 # futures 0.3 futures (the kind produced by the new `async`/`await!` language
 # feature).
-tokio = { version = "0.1.11", features = ["async-await-preview"] }
+tokio = { version = "0.1.16", features = ["async-await-preview"] }
 ```
 
 Now that we've got our dependencies out of the way, let's start writing some


### PR DESCRIPTION
As there were several issues about this, and people seem to particularly like this example, I updated it so it works again. This should close #5, rust-lang-nursery/futures-rs#1462.

There is another issue though that does not get resolved here. This example demonstrates how to asynchronously fetch a different website to return the response to hyper. However the chosen url is particularly poor: `http://www.rust-lang.org/en-US/`. 
1. This does a 301 redirect to https. So we just send that back and the browser url bar changes from 127.0.0.1 to `https://www.rust-lang.org/en-US/`, which is a bit confusing, and I think not the intention of the example.
2. The final https url returns a 404...

I tried to send it to the main page of rust-lang.org in https, but hyper::Client does not seem to support https out of the box. I think it would be best to replace the url with some good example page that does not redirect to https, but I couldn't find one immediately. I also created an examples branch which has the working example as proof it works. I will make a pull request, but I don't know if having examples in this repository is desirable.
 