### PR TITLE
Fix two typos on io.md

### DIFF
--- a/src/execution/io.md
+++ b/src/execution/io.md
@@ -73,13 +73,13 @@ impl IoBlocker {
         io_object: &IoObject,
 
         /// A set of signals that may appear on the `io_object` for
-        /// which an event should be triggered, paried with
+        /// which an event should be triggered, paired with
         /// an ID to give to events that result from this interest.
         event: Event,
     ) { ... }
 
     /// Block until one of the events occurs.
-    /// This will only trigget
+    /// This will only trigger ...
     fn block(&self) -> Event { ... }
 }
 


### PR DESCRIPTION
There's also the fact that the second comment I updated seems to be incomplete, so maybe we can just fix the typos once the section is finished. However I thought I'd point them out with a fix regardless.