### PR TITLE
Fix some references to the old await! syntax

### DIFF
--- a/examples/01_04_async_await_primer/src/lib.rs
+++ b/examples/01_04_async_await_primer/src/lib.rs
@@ -43,7 +43,7 @@ mod third {
 use super::*;
 async fn learn_and_sing() {
     // Wait until the song has been learned before singing it.
-    // We use `await!` here rather than `block_on` to prevent blocking the
+    // We use `.await` here rather than `block_on` to prevent blocking the
     // thread, which makes it possible to `dance` at the same time.
     let song = learn_song().await;
     sing_song(song).await;
@@ -53,7 +53,7 @@ async fn async_main() {
     let f1 = learn_and_sing();
     let f2 = dance();
 
-    // `join!` is like `await!` but can wait for multiple futures concurrently.
+    // `join!` is like `.await` but can wait for multiple futures concurrently.
     // If we're temporarily blocked in the `learn_and_sing` future, the `dance`
     // future will take over the current thread. If `dance` becomes blocked,
     // `learn_and_sing` can take back over. If both futures are blocked, then


### PR DESCRIPTION
Noticed these while I was skimming the book - as far as I can tell they're the only two references to `await!` that haven't been updated yet.