### PR TITLE
Cache mdbook and linkcheck

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,11 @@ language: rust
 cache: cargo
 rust: nightly-2019-08-21 # minimum required version for async/await
 
-before_install:
-  - cargo install mdbook --vers '0.3.1' --debug --force
-  - cargo install mdbook-linkcheck --vers '0.3.1' --debug --force
+before_script:
+  - (test -x $HOME/.cargo/bin/cargo-install-update || cargo install cargo-update)
+  - (test -x $HOME/.cargo/bin/mdbook || cargo install --vers "0.3.1" --debug --force mdbook)
+  - (test -x $HOME/.cargo/bin/mdbook-linkcheck || cargo install --vers "0.3.1" --debug --force mdbook-linkcheck)
+  - cargo install-update -a
 
 script:
   - mdbook build


### PR DESCRIPTION
Added caching mdbook and linkcheck (as described [here](https://rust-lang-nursery.github.io/mdBook/continuous-integration.html#ensuring-your-book-builds-and-tests-pass))