### PR TITLE
CH1 - HTTP server - wrong url + missing println!

### DIFF
--- a/examples/01_05_http_server/src/lib.rs
+++ b/examples/01_05_http_server/src/lib.rs
@@ -96,6 +96,7 @@ let url = url_str.parse::<Uri>().expect("failed to parse URL");
 // ANCHOR_END: parse_url
 
 // ANCHOR: get_request
+println!("making request to {}", url);
 let res = Client::new().get(url).compat().await;
 // Return the result of the request directly to the user
 println!("request finished-- returning response");

--- a/src/01_getting_started/05_http_server_example.md
+++ b/src/01_getting_started/05_http_server_example.md
@@ -67,12 +67,12 @@ When we `.await` that future, an HTTP request is sent out, the current task
 is suspended, and the task is queued to be continued once a response has
 become available.
 
-Now, if you `cargo run` and open `http://127.0.0.1:3000/foo` in your browser,
+Now, if you `cargo run` and open `http://127.0.0.1:3000/` in your browser,
 you'll see the Rust homepage, and the following terminal output:
 
 ```
 Listening on http://127.0.0.1:3000
-Got request at /foo
+Got request at /
 making request to http://www.rust-lang.org/en-US/
 request finished-- returning response
 ```


### PR DESCRIPTION
Hello!

While reading chapter 1 of the book I found out that the second example of the HTTP server (the one with the `hyper::Client`, this url `http://127.0.0.1:3000/foo` is supposed to be used to test the example, which is incorrect based on the code.

Also a `println!` is missing from the code based on the output of the example, so I added it back (`println!("making request to {}", url);`).
Another solution may be to remove it from the output.