### PR TITLE
Add required hidden definitions to some code examples

### DIFF
--- a/src/07_workarounds/04_send_approximation.md
+++ b/src/07_workarounds/04_send_approximation.md
@@ -20,6 +20,9 @@ Variables of type `NotSend` can briefly appear as temporaries in `async fn`s
 even when the resulting `Future` type returned by the `async fn` must be `Send`:
 
 ```rust
+# use std::rc::Rc;
+# #[derive(Default)]
+# struct NotSend(Rc<()>);
 async fn bar() {}
 async fn foo() {
     NotSend::default();
@@ -37,6 +40,9 @@ However, if we change `foo` to store `NotSend` in a variable, this example no
 longer compiles:
 
 ```rust
+# use std::rc::Rc;
+# #[derive(Default)]
+# struct NotSend(Rc<()>);
 async fn foo() {
     let x = NotSend::default();
     bar().await;
@@ -80,6 +86,9 @@ for the compiler to tell that these variables do not live across an
 `.await` point.
 
 ```rust
+# use std::rc::Rc;
+# #[derive(Default)]
+# struct NotSend(Rc<()>);
 async fn foo() {
     {
         let x = NotSend::default();


### PR DESCRIPTION
Otherwise the code examples fail to compile for the wrong reason.

This still doesn't compile because mdbook is forcing the 2015 edition, but that needs to be fixed as an mdbook config which I'm adding shortly.