### PR TITLE
Fix pinning example

### DIFF
--- a/src/04_pinning/01_chapter.md
+++ b/src/04_pinning/01_chapter.md
@@ -40,7 +40,9 @@ enum State {
 }
 
 impl Future for AsyncFuture {
-    fn poll(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
+    type Output = ();
+
+    fn poll(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<()> {
         loop {
             match self.state {
                 State::AwaitingFutOne => match self.fut_one.poll(..) {


### PR DESCRIPTION
The existing `AsyncFuture` example wouldn't compile due to missing the Future trait's required `Output` type and not marking `self` as mutable (required to update `AsyncFuture::state`).