### PR TITLE
Don't start the timer until the future is polled for the first time.

### DIFF
--- a/examples/02_03_timer/src/lib.rs
+++ b/examples/02_03_timer/src/lib.rs
@@ -21,6 +21,9 @@ struct SharedState {
     /// Whether or not the sleep time has elapsed
     completed: bool,
 
+    /// How long to sleep once the future is first polled
+    duration: Duration,
+
     /// The waker for the task that `TimerFuture` is running on.
     /// The thread can use this after setting `completed = true` to tell
     /// `TimerFuture`'s task to wake up, see that `completed = true`, and
@@ -36,23 +39,40 @@ impl Future for TimerFuture {
         // Look at the shared state to see if the timer has already completed.
         let mut shared_state = self.shared_state.lock().unwrap();
         if shared_state.completed {
-            Poll::Ready(())
-        } else {
-            // Set waker so that the thread can wake up the current task
-            // when the timer has completed, ensuring that the future is polled
-            // again and sees that `completed = true`.
-            //
-            // It's tempting to do this once rather than repeatedly cloning
-            // the waker each time. However, the `TimerFuture` can move between
-            // tasks on the executor, which could cause a stale waker pointing
-            // to the wrong task, preventing `TimerFuture` from waking up
-            // correctly.
-            //
-            // N.B. it's possible to check for this using the `Waker::will_wake`
-            // function, but we omit that here to keep things simple.
-            shared_state.waker = Some(cx.waker().clone());
-            Poll::Pending
+            return Poll::Ready(());
         }
+
+        // If we don't have a waker it is because the timer thread hasn't
+        // been started yet. Start it now.
+        if shared_state.waker.is_none() {
+            let thread_shared_state = self.shared_state.clone();
+            let thread_duration = shared_state.duration;
+            thread::spawn(move || {
+                thread::sleep(thread_duration);
+                let mut shared_state = thread_shared_state.lock().unwrap();
+                // Signal that the timer has completed and wake up the last
+                // task on which the future was polled, if one exists.
+                shared_state.completed = true;
+                if let Some(waker) = shared_state.waker.take() {
+                    waker.wake()
+                }
+            });
+        }
+
+        // Set waker so that the thread can wake up the current task
+        // when the timer has completed, ensuring that the future is polled
+        // again and sees that `completed = true`.
+        //
+        // It's tempting to do this once rather than repeatedly cloning
+        // the waker each time. However, the `TimerFuture` can move between
+        // tasks on the executor, which could cause a stale waker pointing
+        // to the wrong task, preventing `TimerFuture` from waking up
+        // correctly.
+        //
+        // N.B. it's possible to check for this using the `Waker::will_wake`
+        // function, but we omit that here to keep things simple.
+        shared_state.waker = Some(cx.waker().clone());
+        Poll::Pending
     }
 }
 // ANCHOR_END: future_for_timer
@@ -64,21 +84,9 @@ impl TimerFuture {
     pub fn new(duration: Duration) -> Self {
         let shared_state = Arc::new(Mutex::new(SharedState {
             completed: false,
+            duration,
             waker: None,
         }));
-
-        // Spawn the new thread
-        let thread_shared_state = shared_state.clone();
-        thread::spawn(move || {
-            thread::sleep(duration);
-            let mut shared_state = thread_shared_state.lock().unwrap();
-            // Signal that the timer has completed and wake up the last
-            // task on which the future was polled, if one exists.
-            shared_state.completed = true;
-            if let Some(waker) = shared_state.waker.take() {
-                waker.wake()
-            }
-        });
 
         TimerFuture { shared_state }
     }

--- a/src/02_execution/03_wakeups.md
+++ b/src/02_execution/03_wakeups.md
@@ -45,8 +45,14 @@ Now, let's actually write the `Future` implementation!
 ```
 
 Pretty simple, right? If the thread has set `shared_state.completed = true`,
-we're done! Otherwise, we clone the `Waker` for the current task and pass it to
-`shared_state.waker` so that the thread can wake the task back up.
+we're done! Otherwise, the timer either hasn't started yet, or it is running 
+but hasn't completed. To figure this out we look at the `waker` field.
+
+If we do not have `Waker`, the timer hasn't started yet and so we spawn the 
+timer thread and set a `Waker`. If we do have a `Waker` it means the timer 
+was started but hasn't completed yet. We clone the `Waker` for the current 
+task and pass it to `shared_state.waker`  so that the thread can wake the 
+task back up.
 
 Importantly, we have to update the `Waker` every time the future is polled
 because the future may have moved to a different task with a different


### PR DESCRIPTION
A typical Rust future won't start performing work until the first time it is polled. The current timer example starts the timer when the future is created instead of when the future is first polled.

This PR modifies the timer example to not start the timer thread until the future is polled for the first time.