### PR TITLE
Add a workaround for joining futures and allowing some to fail without failing everything

### DIFF
--- a/examples/07_07_join_failing_futures/Cargo.toml
+++ b/examples/07_07_join_failing_futures/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "07_07_join_failing_futures"
+version = "0.1.0"
+authors = ["tarquin-the-brave <tomsteavenson@gmail.com>"]
+edition = "2018"
+
+[lib]
+
+[dependencies]
+failure = "0.1.6"
+futures = "0.3.1"

--- a/examples/07_07_join_failing_futures/src/lib.rs
+++ b/examples/07_07_join_failing_futures/src/lib.rs
@@ -1,0 +1,54 @@
+// ANCHOR: example
+//!
+//! Get the results of a collection of futures.
+//!
+//! Using async await syntax and futures 0.3.
+//!
+use failure::{format_err, Error};
+use futures::{
+    future::join_all,
+    executor::block_on,
+};
+
+enum Outcome {
+    Good,
+    Bad,
+}
+
+// Function to model a future that can fail given either good or
+// bad input.
+async fn get_single_future(outcome: Outcome) -> Result<String, Error> {
+    match outcome {
+        Outcome::Good => Ok("Success!".to_string()),
+        Outcome::Bad => Err(format_err!("Failure")),
+    }
+}
+
+async fn get_joined_future() -> Vec<Result<String, Error>> {
+    // Let outcomes model the success of the futures we're going to get.
+    let outcomes = vec![Outcome::Good, Outcome::Bad, Outcome::Good];
+
+    let packed_futures = outcomes
+        .into_iter()
+        .map(|outcome| async {
+            // Pack the result of each future into an Ok which we'll unwrap
+            // after joining.
+            match get_single_future(outcome).await {
+                // We need to tell the compiler the Err type of the Result
+                // we're wrapping our futures' results in.  As we'll never use
+                // it, say it's ().
+                Ok(message) => Ok::<Result<String, Error>, ()>(Ok(message)),
+                Err(whoopsie) => Ok(Err(whoopsie)),
+            }
+        })
+        .collect::<Vec<_>>();
+
+    // join_all with return a Vec of results which we know we can unwrap
+    // as the match above never creates an Err variant.
+    join_all(packed_futures).await.into_iter().map(|x| x.unwrap()).collect()
+}
+
+pub fn get_results() -> Vec<Result<String, Error>> {
+    block_on(get_joined_future())
+}
+// ANCHOR_END: example

--- a/examples/Cargo.toml
+++ b/examples/Cargo.toml
@@ -12,4 +12,5 @@ members = [
   "06_02_join",
   "06_03_select",
   "07_05_recursion",
+  "07_07_join_failing_futures",
 ]

--- a/src/07_workarounds/07_join_failing_futures.md
+++ b/src/07_workarounds/07_join_failing_futures.md
@@ -1,0 +1,27 @@
+# Joining Futures that May Fail
+
+When we have a collection of futures that we want to wait on, e.g.
+we've sent off a bunch of requests and want to wait for them all to
+come back before continuing, we can join the futures into one with
+one of the join functions[^1] and `await` the resultant future which
+will return a collection of the results from each future.
+
+If one of the futures that were joined fails, the joined future will
+fail.  This behavior isn't always desired.
+
+We can workaround this to get the results of _all_ the futures by packing
+the futures' results into the `Ok` variant of another `Result`, then unwrap
+the results once the joined future returns.
+
+```rust
+{{#include ../../examples/07_07_join_failing_futures/src/lib.rs:example}}
+```
+
+[^1]: Functions to join different numbers of futures from [`futures::future`](https://docs.rs/futures/0.3.1/futures/future/index.html) -
+[`join`](https://docs.rs/futures/0.3.1/futures/future/fn.join.html),
+[`join3`](https://docs.rs/futures/0.3.1/futures/future/fn.join3.html),
+[`join4`](https://docs.rs/futures/0.3.1/futures/future/fn.join4.html),
+[`join5`](https://docs.rs/futures/0.3.1/futures/future/fn.join5.html),
+and [`join_all`](https://docs.rs/futures/0.3.1/futures/future/fn.join_all.html) for any number of futures.
+The corresponding [`try_join`](https://docs.rs/futures/0.3.1/futures/future/fn.try_join.html)
+functions will return as soon as one future returns an error.

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -26,6 +26,7 @@
   - [`Send` Approximation](07_workarounds/04_send_approximation.md)
   - [Recursion](07_workarounds/05_recursion.md)
   - [`async` in Traits](07_workarounds/06_async_in_traits.md)
+  - [Joining Futures that May Fail](07_workarounds/07_join_failing_futures.md)
 - [TODO: I/O](404.md)
   - [TODO: `AsyncRead` and `AsyncWrite`](404.md)
 - [TODO: Asynchronous Design Patterns: Solutions and Suggestions](404.md)


### PR DESCRIPTION
Hi,

This is a problem I first hit a while back while writing with old style `0.1` futures.  Speaking with some of the people I work with who also hit this problem, we all used the same workaround. I've used this as an exercise to get my head around the `async`/`await` syntax and futures `0.3` API.

Let me know what you think!