### PR TITLE
Update `Hyper` example in chapter 1.4

### DIFF
--- a/ci/dictionary.txt
+++ b/ci/dictionary.txt
@@ -23,7 +23,6 @@ FusedStream
 FutOne
 FutTwo
 FutureObj
-FutureResponse
 FuturesUnordered
 GenFuture
 http
@@ -52,6 +51,7 @@ ReadIntoBuf
 recognise
 RefCell
 requeue
+ResponseFuture
 reusability
 runtime
 rustc

--- a/examples/01_05_http_server/Cargo.toml
+++ b/examples/01_05_http_server/Cargo.toml
@@ -1,22 +1,18 @@
 [package]
 name = "01_05_http_server"
-version = "0.1.0"
+version = "0.2.0"
 authors = ["Taylor Cramer <cramertj@google.com>"]
 edition = "2018"
 
 [lib]
 
 [dependencies]
-# The latest version of the "futures" library, which has lots of utilities
-# for writing async code. Enable the "compat" feature to include the
-# functions for using futures 0.3 and async/await with the Hyper library,
-# which use futures 0.1.
-futures = { version = "0.3", features = ["compat"] }
-
 # Hyper is an asynchronous HTTP library. We'll use it to power our HTTP
 # server and to make HTTP requests.
-hyper = "0.12.9"
+hyper = "0.13.0"
+# To setup some sort of runtime needed by Hyper, we will use the Tokio runtime.
+tokio = { version = "0.2", features = ["full"] }
 
 # (only for testing)
-failure = "0.1.5"
-reqwest = "0.9.18"
+failure = "0.1.6"
+reqwest = "0.9.24"

--- a/src/01_getting_started/05_http_server_example.md
+++ b/src/01_getting_started/05_http_server_example.md
@@ -58,9 +58,9 @@ returning the response to the user:
 {{#include ../../examples/01_05_http_server/src/lib.rs:get_request}}
 ```
 
-`Client::get` returns a `hyper::client::FutureResponse`, which implements
-`Future<Output = Result<Response, Error>>`
-(or `Future<Item = Response, Error = Error>` in futures 0.1 terms).
+`Client::get` returns a `hyper::client::ResponseFuture`, which implements
+`Future<Output = Result<Response<Body>>>`
+(or `Future<Item = Response<Body>, Error = Error>` in futures 0.1 terms).
 When we `.await` that future, an HTTP request is sent out, the current task
 is suspended, and the task is queued to be continued once a response has
 become available.


### PR DESCRIPTION
for using latest `Hyper` `v.0.13.0`, which supports `async/await` out of
the box.