### PR TITLE
mdbook renderer tries to invoke linkcheck renderer

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,7 @@ The async book is built with [`mdbook`], you can install it using cargo.
 
 ```
 cargo install mdbook
+cargo install mdbook-linkcheck
 ```
 
 [`mdbook`]: https://github.com/rust-lang/mdBook


### PR DESCRIPTION
While running `mdbook build` or `mdbook serve` I could see the following log lines:
Running the linkcheck backend
Invoking the "linkcheck" renderer
The command wasn't found, is the "linkcheck" backend installed?
Command: mdbook-linkcheck