### PR TITLE
Add Async Recursion Macro to Workarounds

### DIFF
--- a/src/07_workarounds/05_recursion.md
+++ b/src/07_workarounds/05_recursion.md
@@ -55,3 +55,19 @@ to make `recursive` into a non-`async` function which returns a `.boxed()`
 ```rust,edition2018
 {{#include ../../examples/07_05_recursion/src/lib.rs:example}}
 ```
+
+## Using a Macro
+
+There is also a community-developed macro, [`async-recursion`](https://github.com/dcchut/async-recursion), that can be used to automatically transform an async function to return a boxed future:
+
+```rust
+use async_recursion::async_recursion;
+
+#[async_recursion]
+async fn recursive() {
+    recursive().await;
+    recursive().await;
+}
+```
+
+This allows the function to recurse without you having to manually change the method signature and body.


### PR DESCRIPTION
This may not be something you want in the book, but there is a nifty macro crate for automatically transforming async functions to return boxed futures that could be useful to people.

I noticed the other example was in a separate file, but this is a super small example so I just inlined it. I can change it if you like.