### PR TITLE
Add link to Cargo dependencies example

### DIFF
--- a/src/01_getting_started/04_async_await_primer.md
+++ b/src/01_getting_started/04_async_await_primer.md
@@ -7,6 +7,12 @@ blocking function in a synchronous method would block the whole thread,
 blocked `Future`s will yield control of the thread, allowing other
 `Future`s to run.
 
+Let's add some dependencies to the `Cargo.toml` file:
+
+```toml
+{{#include ../../examples/01_04_async_await_primer/Cargo.toml:9:10}}
+```
+
 To create an asynchronous function, you can use the `async fn` syntax:
 
 ```rust,edition2018


### PR DESCRIPTION
To facilitate an uninterrupted demo experience for the reader, this PR includes the relevant portion of an existing `Cargo.toml` file noting the reliance of the `futures` crate.