### PR TITLE
Equalize .await to always use the `.` prefix

### DIFF
--- a/src/01_getting_started/03_state_of_async_rust.md
+++ b/src/01_getting_started/03_state_of_async_rust.md
@@ -3,7 +3,7 @@
 The asynchronous Rust ecosystem has undergone a lot of evolution over time,
 so it can be hard to know what tools to use, what libraries to invest in,
 or what documentation to read. However, the `Future` trait inside the standard
-library and the `async`/`await` language feature has recently been stabilized.
+library and the `async`/`.await` language feature has recently been stabilized.
 The ecosystem as a whole is therefore in the midst of migrating
 to the newly-stabilized API, after which point churn will be significantly
 reduced.
@@ -12,7 +12,7 @@ At the moment, however, the ecosystem is still undergoing rapid development
 and the asynchronous Rust experience is unpolished. Most libraries still
 use the 0.1 definitions of the `futures` crate, meaning that to interoperate
 developers frequently need to reach for the `compat` functionality from the
-0.3 `futures` crate. The `async`/`await` language feature is still new.
+0.3 `futures` crate. The `async`/`.await` language feature is still new.
 Important extensions like `async fn` syntax in trait methods are still
 unimplemented, and the current compiler error messages can be difficult to
 parse.

--- a/src/02_execution/01_chapter.md
+++ b/src/02_execution/01_chapter.md
@@ -4,9 +4,9 @@ In this section, we'll cover the underlying structure of how `Future`s and
 asynchronous tasks are scheduled. If you're only interested in learning
 how to write higher-level code that uses existing `Future` types and aren't
 interested in the details of how `Future` types work, you can skip ahead to
-the `async`/`await` chapter. However, several of the topics discussed in this
-chapter are useful for understanding how `async`/`await` code works,
-understanding the runtime and performance properties of `async`/`await` code,
+the `async`/`.await` chapter. However, several of the topics discussed in this
+chapter are useful for understanding how `async`/`.await` code works,
+understanding the runtime and performance properties of `async`/`.await` code,
 and building new asynchronous primitives. If you decide to skip this section
 now, you may want to bookmark it to revisit in the future.
 

--- a/src/08_example/01_running_async_code.md
+++ b/src/08_example/01_running_async_code.md
@@ -28,11 +28,11 @@ warning: unused implementer of `std::future::Future` that must be used
    = note: futures do nothing unless you `.await` or poll them
 ```
 
-Because we haven't `await`ed or `poll`ed the result of `handle_connection`,
+Because we haven't `.await`ed or `poll`ed the result of `handle_connection`,
 it'll never run. If you run the server and visit `127.0.0.1:7878` in a browser,
 you'll see that the connection is refused; our server is not handling requests.
 
-We can't `await` or `poll` futures within synchronous code by itself.
+We can't `.await` or `poll` futures within synchronous code by itself.
 We'll need an asynchronous runtime to handle scheduling and running futures to completion.
 Please consult the section on choosing a runtime for more information on asynchronous runtimes, executors, and reactors.
 
@@ -49,7 +49,7 @@ features = ["attributes"]
 ```
 
 As a first step, we'll switch to an asynchronous main function,
-and `await` the future returned by the async version of `handle_connection`.
+and `.await` the future returned by the async version of `handle_connection`.
 Then, we'll test how the server responds.
 Here's what that would look like:
 ```rust
@@ -70,11 +70,11 @@ This is very similar to the
 [simulation of a slow request](https://doc.rust-lang.org/book/ch20-02-multithreaded.html#simulating-a-slow-request-in-the-current-server-implementation)
 from the Book, but with one important difference:
 we're using the non-blocking function `async_std::task::sleep` instead of the blocking function `std::thread::sleep`.
-It's important to remember that even if a piece of code is run within an `async fn` and `await`ed, it may still block.
+It's important to remember that even if a piece of code is run within an `async fn` and `.await`ed, it may still block.
 To test whether our server handles connections concurrently, we'll need to ensure that `handle_connection` is non-blocking.
 
 If you run the server, you'll see that a request to `127.0.0.1:7878/sleep`
 will block any other incoming requests for 5 seconds!
 This is because there are no other concurrent tasks that can make progress
-while we are `await`ing the result of `handle_connection`.
+while we are `.await`ing the result of `handle_connection`.
 In the next section, we'll see how to use async code to handle connections concurrently.

--- a/src/SUMMARY.md
+++ b/src/SUMMARY.md
@@ -9,7 +9,7 @@
   - [Task Wakeups with `Waker`](02_execution/03_wakeups.md)
   - [Applied: Build an Executor](02_execution/04_executor.md)
   - [Executors and System IO](02_execution/05_io.md)
-- [`async`/`await`](03_async_await/01_chapter.md)
+- [`async`/`.await`](03_async_await/01_chapter.md)
 - [Pinning](04_pinning/01_chapter.md)
 - [Streams](05_streams/01_chapter.md)
   - [Iteration and Concurrency](05_streams/02_iteration_and_concurrency.md)


### PR DESCRIPTION
Sometimes `await` is used with the `.` prefix and sometimes it's written without.