### PR TITLE
fix(Chapter 9): ensure src and dst has same size before copy_from_slice

### DIFF
--- a/examples/09_05_final_tcp_server/src/main.rs
+++ b/examples/09_05_final_tcp_server/src/main.rs
@@ -61,7 +61,7 @@ mod tests {
             buf: &mut [u8],
         ) -> Poll<Result<usize, Error>> {
             let size: usize = min(self.read_data.len(), buf.len());
-            buf.copy_from_slice(&self.read_data[..size]);
+            buf[..size].copy_from_slice(&self.read_data[..size]);
             Poll::Ready(Ok(size))
         }
     }


### PR DESCRIPTION
The example code will panic when the capacity of buf is bigger than self.read_data