### PR TITLE
Clarify `Future` expectations

### DIFF
--- a/src/02_execution/02_future.md
+++ b/src/02_execution/02_future.md
@@ -1,9 +1,9 @@
 # The `Future` Trait
 
-The `Future` trait is at the center of asynchronous programming in Rust.
-A `Future` is an asynchronous computation that can produce a value
-(although that value may be empty, e.g. `()`). A *simplified* version of
-the future trait might look something like this:
+The `Future` trait is at the center of asynchronous programming in Rust. A
+`Future` is an asynchronous computation that can produce a value (although
+that value may be empty, e.g. `()`) and is typically expected to complete. A
+*simplified* version of the future trait might look something like this:
 
 ```rust
 {{#include ../../examples/02_02_future_trait/src/lib.rs:simple_future}}


### PR DESCRIPTION
From https://internals.rust-lang.org/t/future-and-its-assurance-of-completion/14542/11, originating with https://internals.rust-lang.org/t/future-and-its-assurance-of-completion/14542/10, the suggested change adds helpful information IMHO.