### PR TITLE
add instructions to create project as timer_future

### DIFF
--- a/src/02_execution/03_wakeups.md
+++ b/src/02_execution/03_wakeups.md
@@ -23,7 +23,8 @@ For the sake of the example, we'll just spin up a new thread when the timer
 is created, sleep for the required time, and then signal the timer future
 when the time window has elapsed.
 
-Here are the imports we'll need to get started:
+First, start a new project with `cargo new timer_future` and add the imports
+we'll need to get started to `src/lib.rs`:
 
 ```rust
 {{#include ../../examples/02_03_timer/src/lib.rs:imports}}


### PR DESCRIPTION
To avoid breaking implicit project naming assumptions when referencing `timer_future::TimerFuture` from `main.rs` in section 2.3

(I got tripped up by the `use` path because I had named my project `timer` instead and initially wasn't sure why a `crate::` path wasn't working before finding the explanation in https://stackoverflow.com/questions/57756927/rust-modules-confusion-when-there-is-main-rs-and-lib-rs that `main` and `lib` are compiled as separate crates, and the package name is used to reference across them.)