### PR TITLE
Minor changes to Applied: Build and executor

### DIFF
--- a/src/02_execution/04_executor.md
+++ b/src/02_execution/04_executor.md
@@ -17,11 +17,12 @@ In this section, we'll write our own simple executor capable of running a large
 number of top-level futures to completion concurrently.
 
 For this example, we depend on the `futures` crate for the `ArcWake` trait,
-which provides an easy way to construct a `Waker`.
+which provides an easy way to construct a `Waker`. Edit `Cargo.toml` to add
+a new dependency:
 
 ```toml
 [package]
-name = "xyz"
+name = "timer_future"
 version = "0.1.0"
 authors = ["XYZ Author"]
 edition = "2018"


### PR DESCRIPTION
The instructions didn't mention which file to edit to add the dependency. Further, since the previous section (https://github.com/rust-lang/async-book/blob/master/src/02_execution/03_wakeups.md) used `cargo new timer_future` to create the project, we know the package name is `timer_future`.