### PR TITLE
update cargo new command with --lib

### DIFF
--- a/src/02_execution/03_wakeups.md
+++ b/src/02_execution/03_wakeups.md
@@ -23,7 +23,7 @@ For the sake of the example, we'll just spin up a new thread when the timer
 is created, sleep for the required time, and then signal the timer future
 when the time window has elapsed.
 
-First, start a new project with `cargo new timer_future` and add the imports
+First, start a new project with `cargo new --lib timer_future` and add the imports
 we'll need to get started to `src/lib.rs`:
 
 ```rust


### PR DESCRIPTION
The current `cargo new timer_future` command generates `src/main.rs`, not `src/lib.rs` mentioned later.