### PR TITLE
fix: pinning  examples

### DIFF
--- a/src/04_pinning/01_chapter.md
+++ b/src/04_pinning/01_chapter.md
@@ -247,7 +247,7 @@ a: test1, b: test1
 But instead we get:
 
 ```rust, ignore
-a: test1, b: test1
+a: test2, b: test1
 a: test1, b: test2
 ```
 


### PR DESCRIPTION
Update the sample output of std::mem::swap example
in the pinning chapter