### PR TITLE
add the translation of zh-CN to the appendix

### DIFF
--- a/src/12_appendix/01_translations.md
+++ b/src/12_appendix/01_translations.md
@@ -4,3 +4,4 @@ For resources in languages other than English.
 
 - [Русский](https://doc.rust-lang.ru/async-book/)
 - [Français](https://jimskapt.github.io/async-book-fr/)
+- [简体中文](https://huangjj27.github.io/async-book/)


### PR DESCRIPTION
I have updated the translation to the newest version of the async book of the English version, so I add it to the appendix