### PR TITLE
Remove unused use-statement

### DIFF
--- a/examples/02_04_executor/src/lib.rs
+++ b/examples/02_04_executor/src/lib.rs
@@ -10,7 +10,7 @@ use {
         future::Future,
         sync::mpsc::{sync_channel, Receiver, SyncSender},
         sync::{Arc, Mutex},
-        task::{Context, Poll},
+        task::Context,
         time::Duration,
     },
     // The timer we wrote in the previous section:


### PR DESCRIPTION
The enum Poll is never used in the demo codes and even the documentation. 