### PR TITLE
Use install-action to install mdbook and mdbook-linkcheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,20 +9,16 @@ on:
 jobs:
   test:
     name: build and test
-    env:
-      MDBOOK_LINKCHECK_VERSION: 0.7.0
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
       - name: Install Rust
         run: rustup update stable && rustup default stable
       - run: sudo apt-get update && sudo apt-get install aspell aspell-en
-      - name: Install mdbook and mdbook-linkcheck
-        run: |
-          tag=$(curl -LsSf https://api.github.com/repos/rust-lang/mdBook/releases/latest | jq -r '.tag_name')
-          curl -LsSf https://github.com/rust-lang/mdBook/releases/download/$tag/mdbook-$tag-x86_64-unknown-linux-gnu.tar.gz | tar xzf -
-          curl -LsSf https://github.com/Michael-F-Bryan/mdbook-linkcheck/releases/download/v${MDBOOK_LINKCHECK_VERSION}/mdbook-linkcheck-v${MDBOOK_LINKCHECK_VERSION}-x86_64-unknown-linux-gnu.tar.gz | tar xzf -
-          echo $(pwd) >> $GITHUB_PATH
+      - name: Install mdbook
+        uses: taiki-e/install-action@mdbook
+      - name: Install mdbook-linkcheck
+        uses: taiki-e/install-action@mdbook-linkcheck
       - run: bash ci/spellcheck.sh list
       - run: mdbook build
       - run: cargo test --all --manifest-path=./examples/Cargo.toml --target-dir ./target


### PR DESCRIPTION
Make installation more robust.