### PR TITLE
Revert "Fix a typo in async/.await chapter"

### DIFF
--- a/src/03_async_await/01_chapter.md
+++ b/src/03_async_await/01_chapter.md
@@ -72,7 +72,7 @@ This means that it is not safe to use `Rc`, `&RefCell` or any other types
 that don't implement the `Send` trait, including references to types that don't
 implement the `Sync` trait.
 
-(Caveat: it is possible to use these types as long as they aren't in scope
+(Caveat: it is possible to use these types so long as they aren't in scope
 during a call to `.await`.)
 
 Similarly, it isn't a good idea to hold a traditional non-futures-aware lock


### PR DESCRIPTION
This reverts commit e6b6c1e01e0b0f4b16aaf4a0f3e63869bf9c3625. 

I learned that it was not a typo. In fact, it might have a slightly different meaning, so I want to keep the author's wording. Sorry for the trouble 🙏 English is not my first language.