### PR TITLE
07 workarounds/async in trait: update that nightly has mvp

### DIFF
--- a/src/07_workarounds/05_async_in_traits.md
+++ b/src/07_workarounds/05_async_in_traits.md
@@ -1,10 +1,10 @@
 # `async` in Traits
 
-Currently, `async fn` cannot be used in traits. The reasons for this are
-somewhat complex, but there are plans to remove this restriction in the
-future.
+Currently, `async fn` cannot be used in traits on the stable release of Rust.
+Since the 17th November 2022, an MVP of async-fn-in-trait is available on the nightly
+version of the compiler tool chain, [see here for details](https://blog.rust-lang.org/inside-rust/2022/11/17/async-fn-in-trait-nightly.html).
 
-In the meantime, however, this can be worked around using the
+In the meantime, there is a work around for the stable tool chain using the
 [async-trait crate from crates.io](https://github.com/dtolnay/async-trait).
 
 Note that using these trait methods will result in a heap allocation


### PR DESCRIPTION
Update async-fn-in-trait description to refer to the MVP that is included in nightly, see https://blog.rust-lang.org/inside-rust/2022/11/17/async-fn-in-trait-nightly.html