### PR TITLE
fix: remove comma in 02_execution_05_io

### DIFF
--- a/src/02_execution/05_io.md
+++ b/src/02_execution/05_io.md
@@ -53,7 +53,7 @@ impl IoBlocker {
         /// A set of signals that may appear on the `io_object` for
         /// which an event should be triggered, paired with
         /// an ID to give to events that result from this interest.
-        event: Event,
+        event: Event
     ) { /* ... */ }
 
     /// Block until one of the events occurs.


### PR DESCRIPTION
I think if it is the last parameter, there should be no need to add a comma in this chapter https://rust-lang.github.io/async-book/02_execution/05_io.html