### PR TITLE
Fix potential deadlock in the executor

### DIFF
--- a/examples/02_04_executor/src/lib.rs
+++ b/examples/02_04_executor/src/lib.rs
@@ -61,7 +61,7 @@ impl Spawner {
             future: Mutex::new(Some(future)),
             task_sender: self.task_sender.clone(),
         });
-        self.task_sender.send(task).expect("too many tasks queued");
+        self.task_sender.try_send(task).expect("too many tasks queued");
     }
 }
 // ANCHOR_END: spawn_fn
@@ -74,7 +74,7 @@ impl ArcWake for Task {
         let cloned = arc_self.clone();
         arc_self
             .task_sender
-            .send(cloned)
+            .try_send(cloned)
             .expect("too many tasks queued");
     }
 }


### PR DESCRIPTION
`spawn` and `wake` are using a version of the `send` function that "will _block_ until space in the internal buffer becomes available". 

That means that if the channel is full, and we try to spawn a new task or a call to `wake()` was made, `send` will _block_ the thread, the executor will never get the opportunity to free space in the channel's buffer, and the thread will be stuck in a deadlock.

By using `try_send`, instead of `send`, the call will return _immediately_ if the channel's buffer is full, and the call to `expect` will _panic_, as expected.
