### PR TITLE
Updated async dependency

### DIFF
--- a/examples/09_02_async_tcp_server/Cargo.toml
+++ b/examples/09_02_async_tcp_server/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies.async-std]
-version = "1.6"
+version = "1.12"
 features = ["attributes"]

--- a/examples/09_03_slow_request/Cargo.toml
+++ b/examples/09_03_slow_request/Cargo.toml
@@ -7,5 +7,5 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies.async-std]
-version = "1.6"
+version = "1.12"
 features = ["attributes"]

--- a/examples/09_04_concurrent_tcp_server/Cargo.toml
+++ b/examples/09_04_concurrent_tcp_server/Cargo.toml
@@ -10,5 +10,5 @@ edition = "2021"
 futures = "0.3"
 
 [dependencies.async-std]
-version = "1.6"
+version = "1.12"
 features = ["attributes"]

--- a/examples/09_05_final_tcp_server/Cargo.toml
+++ b/examples/09_05_final_tcp_server/Cargo.toml
@@ -10,5 +10,5 @@ edition = "2021"
 futures = "0.3"
 
 [dependencies.async-std]
-version = "1.6"
+version = "1.12"
 features = ["attributes"]


### PR DESCRIPTION
Would be good as the examples should avoid using things that don't work in the latest async-std version