### PR TITLE
Fix: Remove unnecessary pointer dereferencing

### DIFF
--- a/examples/02_04_executor/src/lib.rs
+++ b/examples/02_04_executor/src/lib.rs
@@ -90,7 +90,7 @@ impl Executor {
             if let Some(mut future) = future_slot.take() {
                 // Create a `LocalWaker` from the task itself
                 let waker = waker_ref(&task);
-                let context = &mut Context::from_waker(&*waker);
+                let context = &mut Context::from_waker(&waker);
                 // `BoxFuture<T>` is a type alias for
                 // `Pin<Box<dyn Future<Output = T> + Send + 'static>>`.
                 // We can get a `Pin<&mut dyn Future + Send + 'static>`


### PR DESCRIPTION
Hey folks 👋 ,

First of, thanks for writing this book. I've been learning a ton about async Rust with it. ❤️

And while coding along the [Applied: Build an Executor](https://rust-lang.github.io/async-book/02_execution/04_executor.html#applied-build-an-executor) chapter, I noticed that dereferencing the `waker` reference was unnecessary and this PR fixes that.
https://github.com/rust-lang/async-book/blob/6360806ade20c6dbb604644dfb24704a56f5e191/examples/02_04_executor/src/lib.rs#L93

(Although, I would be happy to learn why in case this is actually necessary.)