### PR TITLE
Small fixes

### DIFF
--- a/src/02_execution/05_io.md
+++ b/src/02_execution/05_io.md
@@ -84,7 +84,7 @@ event occurs. In the case of our `SocketRead` example above, the
 impl Socket {
     fn set_readable_callback(&self, waker: Waker) {
         // `local_executor` is a reference to the local executor.
-        // this could be provided at creation of the socket, but in practice
+        // This could be provided at creation of the socket, but in practice
         // many executor implementations pass it down through thread local
         // storage for convenience.
         let local_executor = self.local_executor;

--- a/src/06_multiple_futures/02_join.md
+++ b/src/06_multiple_futures/02_join.md
@@ -3,7 +3,7 @@
 The `futures::join` macro makes it possible to wait for multiple different
 futures to complete while executing them all concurrently.
 
-# `join!`
+## `join!`
 
 When performing multiple asynchronous operations, it's tempting to simply
 `.await` them in a series:


### PR DESCRIPTION
I've found another fixes:

- Chapter 5: It looks `this` should be `This` here.
- Chapter 6: The heading level `#` appeared twice in the same page. I thought that the latter `join!` one should be aligned with the level of `try_join`, so I demoted the heading level as `##`.