### PR TITLE
Update 03_state_of_async_rust.md for 1.75.0 because async traits have more support now

### DIFF
--- a/src/01_getting_started/03_state_of_async_rust.md
+++ b/src/01_getting_started/03_state_of_async_rust.md
@@ -40,8 +40,8 @@ language features and library support:
   details.
 
 Some language features you may be used to from synchronous Rust are not yet
-available in async Rust. Notably, Rust does not let you declare async
-functions in traits. Instead, you need to use workarounds to achieve the same
+available in async Rust. Notably, Rust did not let you declare async
+functions in traits until 1.75.0 stable (and still has limitations on dynamic dispatch for those traits). Instead, you need to use workarounds to achieve the same
 result, which can be more verbose.
 
 ## Compiling and debugging


### PR DESCRIPTION
Rust 1.75.0 stabilized async fn in traits through RPITIT.