### PR TITLE
Update async fn recursion pattern

### DIFF
--- a/examples/07_05_recursion/src/lib.rs
+++ b/examples/07_05_recursion/src/lib.rs
@@ -11,3 +11,10 @@ fn recursive() -> BoxFuture<'static, ()> {
     }.boxed()
 }
 // ANCHOR_END: example
+
+// ANCHOR: example_pinned
+async fn recursive_pinned() {
+    Box::pin(recursive_pinned()).await;
+    Box::pin(recursive_pinned()).await;
+}
+// ANCHOR_END: example_pinned


### PR DESCRIPTION
Support for recursion in `async fn` has become stable in Rust 1.77. Related articles and examples are updated.

Reference: https://blog.rust-lang.org/2024/03/21/Rust-1.77.0.html#support-for-recursion-in-async-fn