### PR TITLE
Migrate GitHub Pages deployment away from the static-websites action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,23 @@ jobs:
       - run: bash ci/spellcheck.sh list
       - run: mdbook build
       - run: cargo test --all --manifest-path=./examples/Cargo.toml --target-dir ./target
-      - uses: rust-lang/simpleinfra/github-actions/static-websites@master
+      - uses: actions/upload-pages-artifact@v3
         with:
-          deploy_dir: book/html
-          github_token: ${{ secrets.GITHUB_TOKEN }}
+          path: book/html
         if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository_owner == 'rust-lang'
+
+  deploy:
+    name: deploy
+    needs: test
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master' && github.repository_owner == 'rust-lang'
+    permissions:
+      pages: write
+      id-token: write
+    environment:
+      name: github-pages
+      url: ${{steps.deployment.outputs.page_url}}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v4
+        id: deployment


### PR DESCRIPTION
Background: https://github.com/rust-lang/simpleinfra/issues/597

This PR migrates the deployment to GitHub pages away from the custom `static-websites` GHA action to the official [actinos/upload-github-pages-artifact](https://github.com/marketplace/actions/upload-github-pages-artifact) and [actions/deploy-pages](https://github.com/marketplace/actions/deploy-github-pages-site) actions.

For this to work, this repo needs to be configured to use [GitHub Actions as the source for Pages](https://docs.github.com/en/pages/getting-started-with-github-pages/configuring-a-publishing-source-for-your-github-pages-site#publishing-with-a-custom-github-actions-workflow).

I tested this in my own fork and [it seemed to work](https://github.com/miikka/async-book/actions/runs/11275825677) (with the `if:` conditions commented out as they would prevent the interesting parts from running).

