### PR TITLE
Remove incorrect and unnecessary configuration

### DIFF
--- a/book.toml
+++ b/book.toml
@@ -5,8 +5,6 @@ authors = ["Taylor Cramer"]
 [build]
 create-missing = false
 
-[preprocess.links]
-
 [output.html]
 git-repository-url = "https://github.com/rust-lang/async-book"
 site-url = "/async-book/"


### PR DESCRIPTION
`[preprocess.links]` should be written as `[preprocessor.links]`, but actually it is not needed as it is on by default.

See https://rust-lang.github.io/mdBook/format/configuration/preprocessors.html