### PR TITLE
Chapter7 Composing futures Concurrently - code preview typo causing formatting error

### DIFF
--- a/src/part-guide/concurrency-primitives.md
+++ b/src/part-guide/concurrency-primitives.md
@@ -67,7 +67,7 @@ Here's an example using Tokio's [`select`](https://docs.rs/tokio/latest/tokio/ma
 async fn main() {
   select! {
     result = do_a_thing() => {
-      println!("computation completed and returned {result});
+      println!("computation completed and returned {result}");
     }
     _ = timeout() => {
       println!("computation timed-out");


### PR DESCRIPTION
Hi! I was using your book (great reference material, thanks for sharing!) and noticed a small typo in the code snippet. The missing closing quote in the println! caused the code preview to break, making everything after it appear green and harder to read. This PR fixes that typo to restore proper formatting. Thanks for your work!