### PR TITLE
URL of blog post "Tree-Structured Concurrency" seems to be changed

### DIFF
--- a/src/part-reference/structured.md
+++ b/src/part-reference/structured.md
@@ -150,4 +150,4 @@ Given how useful scoped threads are (both in general and for structured concurre
 If you're interested, here are some good blog posts for further reading:
 
 - [Structured Concurrency](https://www.250bpm.com/p/structured-concurrency)
-- [Tree-structured concurrency](https://blog.yoshuawuyts.com/tree-structured-concurrency/)
+- [Tree-structured concurrency](https://blog.yoshuawuyts.com/tree-structured-concurrency/index)


### PR DESCRIPTION
In the References section in section 27 "Structured Concurrency",
two blog posts are listed.

The URL of the second blog post "Tree-Structured Concurrency"
seems to be changed
from https://blog.yoshuawuyts.com/tree-structured-concurrency/
  to https://blog.yoshuawuyts.com/tree-structured-concurrency/index